### PR TITLE
feat: Add automatic log file saving to ~/.cache/dr/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-08-07
+
+### Added
+
+- Automatic log file saving to `~/.cache/dr/` directory
+- Real-time writing of search results to log files
+- Log file path display at command execution start
+- Markdown-formatted log files with date-time timestamps
+- Protection against timeout data loss with persistent logging
+
+## [0.1.0] - 2025-08-07
+
+### Added
+
+- stdin support for piping queries to dr command
+
 ## [0.0.5] - 2025-01-16
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kazuph/mcp-o3-dr",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "build/index.js",
   "bin": {
     "dr": "./build/index.js"


### PR DESCRIPTION
## Summary
- Add automatic log file saving functionality to dr command
- Save all search results to `~/.cache/dr/YYYY-MM-DD-HH-mm-ss.md`
- Display log file path at command execution start

## Changes
- Real-time writing to prevent data loss on timeout
- Markdown-formatted logs with timestamps
- Bump version to 0.1.1

## Test plan
- [x] Test basic dr command execution
- [x] Verify log file creation in ~/.cache/dr/
- [x] Test with stdin input
- [x] Verify real-time writing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)